### PR TITLE
Use active socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides TCP Source and Sink, that read and write to TCP sockets.
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_tcp_plugin, "~> 0.3.0"}
+	{:membrane_tcp_plugin, "~> 0.4.0"}
 ```
 
 ## Copyright and License

--- a/lib/membrane_tcp/common_socket_behaviour.ex
+++ b/lib/membrane_tcp/common_socket_behaviour.ex
@@ -6,6 +6,23 @@ defmodule Membrane.TCP.CommonSocketBehaviour do
   alias Membrane.Element.CallbackContext
   alias Membrane.TCP.Socket
 
+  @type socket_pair_config :: %{
+          connection_side: :server | :client | {:client, :inet.ip_address(), :inet.port_number()},
+          local_address: :inet.socket_address(),
+          local_port_no: :inet.port_number(),
+          local_socket: :gen_tcp.socket() | nil
+        }
+
+  @spec create_socket_pair(socket_pair_config(), keyword()) ::
+          {local_socket :: Socket.t(), remote_socket :: Socket.t() | nil}
+  def create_socket_pair(sockets_config, local_socket_options \\ []) do
+    local_socket = create_local_socket(sockets_config, local_socket_options)
+
+    remote_socket = create_remote_socket(sockets_config, local_socket)
+
+    {local_socket, remote_socket}
+  end
+
   @spec handle_setup(context :: CallbackContext.t(), state :: Element.state()) ::
           Base.callback_return()
   def handle_setup(
@@ -33,6 +50,61 @@ defmodule Membrane.TCP.CommonSocketBehaviour do
       end
 
     handle_local_socket_connection_result(local_socket_connection_result, ctx, state)
+  end
+
+  @spec create_local_socket(socket_pair_config(), [:gen_tcp.option()]) :: Socket.t()
+  defp create_local_socket(%{local_socket: nil} = sockets_config, local_socket_options) do
+    %Socket{
+      ip_address: sockets_config.local_address,
+      port_no: sockets_config.local_port_no,
+      sock_opts: local_socket_options,
+      connection_side: sockets_config.connection_side
+    }
+  end
+
+  defp create_local_socket(%{local_socket: socket_handle} = sockets_config, local_socket_options) do
+    {:ok, {socket_address, socket_port}} = :inet.sockname(socket_handle)
+
+    cond do
+      sockets_config.local_address not in [socket_address, :any] ->
+        raise "Local address passed in options not matching the one of the passed socket."
+
+      sockets_config.local_port_no not in [socket_port, 0] ->
+        raise "Local port passed in options not matching the one of the passed socket."
+
+      not match?({:ok, _peername}, :inet.peername(socket_handle)) ->
+        raise "Local socket not connected."
+
+      true ->
+        :ok
+    end
+
+    :inet.setopts(socket_handle, active: false)
+
+    %Socket{
+      ip_address: sockets_config.local_address,
+      port_no: sockets_config.local_port_no,
+      socket_handle: socket_handle,
+      state: :connected,
+      connection_side: sockets_config.connection_side,
+      sock_opts: local_socket_options
+    }
+  end
+
+  @spec create_remote_socket(socket_pair_config(), Socket.t()) :: Socket.t()
+  defp create_remote_socket(sockets_config, local_socket) do
+    case sockets_config.connection_side do
+      :server ->
+        nil
+
+      :client ->
+        {:ok, {server_address, server_port}} = :inet.peername(local_socket.socket_handle)
+
+        %Socket{ip_address: server_address, port_no: server_port, connection_side: :server}
+
+      {:client, address, port_no} ->
+        %Socket{ip_address: address, port_no: port_no, connection_side: :server}
+    end
   end
 
   @spec handle_local_socket_connection_result(

--- a/lib/membrane_tcp/sink.ex
+++ b/lib/membrane_tcp/sink.ex
@@ -48,7 +48,8 @@ defmodule Membrane.TCP.Sink do
 
   @impl true
   def handle_init(_context, opts) do
-    {local_socket, remote_socket} = Socket.create_socket_pair(Map.from_struct(opts))
+    {local_socket, remote_socket} =
+      CommonSocketBehaviour.create_socket_pair(Map.from_struct(opts))
 
     connection_side =
       case opts.connection_side do
@@ -66,6 +67,9 @@ defmodule Membrane.TCP.Sink do
   end
 
   @impl true
+  defdelegate handle_setup(context, state), to: CommonSocketBehaviour
+
+  @impl true
   def handle_playing(_context, state) do
     {[], state}
   end
@@ -79,9 +83,6 @@ defmodule Membrane.TCP.Sink do
       {:error, cause} -> raise "Error sending TCP packet, reason: #{inspect(cause)}"
     end
   end
-
-  @impl true
-  defdelegate handle_setup(context, state), to: CommonSocketBehaviour
 
   @impl true
   def handle_end_of_stream(_pad, _context, state) do

--- a/lib/membrane_tcp/socket.ex
+++ b/lib/membrane_tcp/socket.ex
@@ -9,7 +9,7 @@ defmodule Membrane.TCP.Socket do
           port_no: :inet.port_number(),
           socket_handle: :gen_tcp.socket() | nil,
           state: :listening | :connected | nil,
-          connection_side: :server | :client | nil,
+          connection_side: :server | :client,
           sock_opts: [:gen_tcp.option()]
         }
 

--- a/lib/membrane_tcp/socket.ex
+++ b/lib/membrane_tcp/socket.ex
@@ -140,6 +140,8 @@ defmodule Membrane.TCP.Socket do
         :ok
     end
 
+    :inet.setopts(socket_handle, active: false)
+
     %__MODULE__{
       ip_address: sockets_config.local_address,
       port_no: sockets_config.local_port_no,

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -60,6 +60,11 @@ defmodule Membrane.TCP.Source do
     flow_control: :manual,
     demand_unit: :buffers
 
+  @typedoc """
+  Notification sent when a local socket handle was provided via `local_socket` option.
+  """
+  @type request_socket_control() :: {:request_socket_control, :gen_tcp.socket(), pid()}
+
   @impl true
   def handle_init(_context, opts) do
     {local_socket, remote_socket} =

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -97,8 +97,8 @@ defmodule Membrane.TCP.Source do
   end
 
   @impl true
-  def handle_demand(_pad, _size, _unit, _ctx, state) do
-    :inet.setopts(state.local_socket.socket_handle, active: :once)
+  def handle_demand(_pad, size, _unit, _ctx, state) do
+    :inet.setopts(state.local_socket.socket_handle, active: size)
     {[], state}
   end
 

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -126,6 +126,11 @@ defmodule Membrane.TCP.Source do
   end
 
   @impl true
+  def handle_info({:tcp_passive, _socket}, _ctx, state) do
+    {[], state}
+  end
+
+  @impl true
   def handle_info({:tcp_error, _socket, reason}, _ctx, _state) do
     raise "TCP Socket receiving error, reason: #{inspect(reason)}"
   end

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -55,7 +55,10 @@ defmodule Membrane.TCP.Source do
                 """
               ]
 
-  def_output_pad :output, accepted_format: %RemoteStream{type: :bytestream}, flow_control: :manual
+  def_output_pad :output,
+    accepted_format: %RemoteStream{type: :bytestream},
+    flow_control: :manual,
+    demand_unit: :buffers
 
   @impl true
   def handle_init(_context, opts) do
@@ -97,7 +100,7 @@ defmodule Membrane.TCP.Source do
   end
 
   @impl true
-  def handle_demand(_pad, size, _unit, _ctx, state) do
+  def handle_demand(_pad, size, :buffers, _ctx, state) do
     :inet.setopts(state.local_socket.socket_handle, active: size)
     {[], state}
   end
@@ -112,7 +115,7 @@ defmodule Membrane.TCP.Source do
       }
 
     {
-      [buffer: {:output, %Buffer{payload: payload, metadata: metadata}}, redemand: :output],
+      [buffer: {:output, %Buffer{payload: payload, metadata: metadata}}],
       state
     }
   end

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -60,7 +60,9 @@ defmodule Membrane.TCP.Source do
   @impl true
   def handle_init(_context, opts) do
     {local_socket, remote_socket} =
-      Socket.create_socket_pair(Map.from_struct(opts), recbuf: opts.recv_buffer_size)
+      CommonSocketBehaviour.create_socket_pair(Map.from_struct(opts),
+        recbuf: opts.recv_buffer_size
+      )
 
     connection_side =
       case opts.connection_side do
@@ -85,6 +87,9 @@ defmodule Membrane.TCP.Source do
        remote_socket: remote_socket
      }}
   end
+
+  @impl true
+  defdelegate handle_setup(context, state), to: CommonSocketBehaviour
 
   @impl true
   def handle_playing(_ctx, state) do
@@ -121,9 +126,6 @@ defmodule Membrane.TCP.Source do
   def handle_info({:tcp_error, _socket, reason}, _ctx, _state) do
     raise "TCP Socket receiving error, reason: #{inspect(reason)}"
   end
-
-  @impl true
-  defdelegate handle_setup(context, state), to: CommonSocketBehaviour
 
   @impl true
   def handle_terminate_request(_ctx, state) do

--- a/lib/membrane_tcp/source.ex
+++ b/lib/membrane_tcp/source.ex
@@ -43,7 +43,7 @@ defmodule Membrane.TCP.Source do
                 and connecting a new one. It's REQUIRED to pass control of it to this element
                 from the previous owner. It can be done by receiving a
                 `{:request_socket_control, socket, pid}` message sent by this element to it's
-                parent and calling `:inet.controlling_process(socket, pid)` (needs to be called by
+                parent and calling `:gen_tcp.controlling_process(socket, pid)` (needs to be called by
                 a process currently controlling the socket)
                 """
               ],
@@ -99,8 +99,6 @@ defmodule Membrane.TCP.Source do
 
   @impl true
   def handle_info({:tcp, _socket, payload}, _ctx, state) do
-    IO.inspect(state.remote_socket, label: "dupa")
-
     metadata =
       %{
         tcp_source_address: state.remote_socket.ip_address,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.TCP.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @github_url "https://github.com/membraneframework/membrane_tcp_plugin"
 
   def project do

--- a/test/membrane_tcp/source/pipeline_test.exs
+++ b/test/membrane_tcp/source/pipeline_test.exs
@@ -114,6 +114,9 @@ defmodule Membrane.TCP.SourcePipelineTest do
           test_process: self()
         )
 
+      assert_pipeline_notified(pipeline, :tcp_source, {:request_socket_control, socket, pid})
+      :gen_tcp.controlling_process(socket, pid)
+
       assert_sink_playing(pipeline, :sink)
 
       run_pipeline(pipeline, server_socket)
@@ -132,6 +135,9 @@ defmodule Membrane.TCP.SourcePipelineTest do
             |> child(:sink, Sink),
           test_process: self()
         )
+
+      assert_pipeline_notified(pipeline, :tcp_source, {:request_socket_control, socket, pid})
+      :gen_tcp.controlling_process(socket, pid)
 
       assert_sink_playing(pipeline, :sink)
 


### PR DESCRIPTION
This PR modifies the Source so that it relies on a `:gen_tcp` socket using active mode rather than non-active, since the latter seems to use a lot more CPU in our implmentation, especially where the demand is higher than supply. To keep the flow control features the socket is using the `active: :once` or `active: N`, which limits the amount of messages that the element will receive before returning to `active: false` state.