### PR TITLE
Handle unexpected disconnect on TCP sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides TCP Source and Sink, that read and write to TCP sockets.
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_tcp_plugin, "~> 0.4.0"}
+	{:membrane_tcp_plugin, "~> 0.5.0"}
 ```
 
 ## Copyright and License

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.TCP.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @github_url "https://github.com/membraneframework/membrane_tcp_plugin"
 
   def project do


### PR DESCRIPTION
The current behavior is raising an exception when TCP disconnects while stream is still not finished. This PR is adding the option `on_connection_closed` that defines what should happen if we attempt to write on a closed socket
